### PR TITLE
chore: slow hero card pulse to 6s

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -151,9 +151,9 @@ export default {
 				'glow-pulse': 'glow-pulse 4s ease-in-out infinite',
 				'marquee': 'marquee 30s linear infinite',
 				'bg-shift': 'bg-shift 15s ease-in-out infinite',
-				'gentle-glow': 'gentle-glow 2s ease-in-out infinite'
-			}
-		}
-	},
-	plugins: [require("tailwindcss-animate")],
+                                'gentle-glow': 'gentle-glow 6s ease-in-out infinite'
+                        }
+                }
+        },
+        plugins: [require("tailwindcss-animate")],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- slow hero card gentle-glow animation to 6s for calmer pulse

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: lint errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68ae7e4826b883319a2287846caa090e