### PR TITLE
chore: slow hero card pulse to 6s

### DIFF
--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -109,7 +109,7 @@ export default function Hero() {
 
 function ChatMockup() {
   return (
-    <Card className="relative bg-gradient-card backdrop-blur-xl border-border/20 p-4 sm:p-6 shadow-card hover:shadow-glow transition-all duration-500 transform hover:scale-[1.02] animate-float">
+    <Card className="relative bg-gradient-card backdrop-blur-xl border-border/20 p-4 sm:p-6 shadow-card hover:shadow-glow transition-all duration-600 transform hover:scale-[1.02] animate-float">
       {/* Header */}
       <div className="flex items-center gap-3 pb-4 border-b border-border/30">
         <div className="w-10 h-10 rounded-full bg-success/30 border-2 border-success/50 flex items-center justify-center">

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -151,9 +151,9 @@ export default {
 				'glow-pulse': 'glow-pulse 4s ease-in-out infinite',
 				'marquee': 'marquee 30s linear infinite',
 				'bg-shift': 'bg-shift 15s ease-in-out infinite',
-				'gentle-glow': 'gentle-glow 2s ease-in-out infinite'
-			}
-		}
-	},
-	plugins: [require("tailwindcss-animate")],
+                                'gentle-glow': 'gentle-glow 6s ease-in-out infinite'
+                        }
+                }
+        },
+        plugins: [require("tailwindcss-animate")],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- slow hero card gentle-glow animation to 6s for calmer pulse
- lengthen hero card hover transition to 600ms for smoother interaction

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 4 errors, 7 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68ae7e4826b883319a2287846caa090e