### PR TITLE
chore: render meta tags statically

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>AGENTISS — Agentes de IA & Landing Pages</title>
-    <meta name="description" content="Agentes de IA que vendem 24/7. Marque consultas, qualifique leads e integre WhatsApp, Instagram e Facebook. Landing Pages que convertem." />
+    <title>AGENTISS — Agentes de IA (Atendimento 24/7) & Landing Pages</title>
+    <meta name="description" content="Agentes de IA no WhatsApp, Instagram e Facebook: tiram dúvidas, marcam/confirmam consultas e qualificam leads. Também criamos Landing Pages que direcionam para as redes e aumentam conversões." />
     <meta name="author" content="AGENTISS" />
-    <meta name="keywords" content="atendimento automático, atendente virtual, agendamento WhatsApp, chatbot, landing page, IA" />
+    <meta name="keywords" content="atendimento automático, atendente virtual, agendamento WhatsApp, chatbot Instagram, chatbot Facebook, landing page, captação de leads" />
 
     <meta property="og:title" content="AGENTISS — Agentes de IA & Landing Pages" />
     <meta property="og:description" content="Atendimento 24/7 com marcação de consultas e LPs que convertem." />

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import Header from "@/components/layout/Header";
 import Footer from "@/components/layout/Footer";
 import Hero from "@/components/sections/Hero";
@@ -13,34 +12,6 @@ import FAQ from "@/components/sections/FAQ";
 import Contact from "@/components/sections/Contact";
 
 const Index = () => {
-  // SEO optimization
-  useEffect(() => {
-    document.title = "AGENTISS — Agentes de IA (Atendimento 24/7) & Landing Pages";
-    
-    const setMeta = (name: string, content: string, isProperty = false) => {
-      const selector = isProperty ? `meta[property='${name}']` : `meta[name='${name}']`;
-      let meta = document.head.querySelector(selector) as HTMLMetaElement;
-      
-      if (!meta) {
-        meta = document.createElement('meta');
-        if (isProperty) {
-          meta.setAttribute('property', name);
-        } else {
-          meta.setAttribute('name', name);
-        }
-        document.head.appendChild(meta);
-      }
-      
-      meta.setAttribute('content', content);
-    };
-
-    setMeta('description', 'Agentes de IA no WhatsApp, Instagram e Facebook: tiram dúvidas, marcam/confirmam consultas e qualificam leads. Também criamos Landing Pages que direcionam para as redes e aumentam conversões.');
-    setMeta('keywords', 'atendimento automático, atendente virtual, agendamento WhatsApp, chatbot Instagram, chatbot Facebook, landing page, captação de leads');
-    setMeta('og:title', 'AGENTISS — Agentes de IA & Landing Pages', true);
-    setMeta('og:description', 'Atendimento 24/7 com marcação de consultas e LPs que convertem.', true);
-    setMeta('og:type', 'website', true);
-  }, []);
-
   return (
     <div className="min-h-screen bg-background text-foreground antialiased">
       <Header />


### PR DESCRIPTION
## Summary
- remove useEffect-based meta tag injection from home page
- rely on static title and meta tags in index.html

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 4 errors, 7 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b25354f0fc833198d16f369e62a97c