### PR TITLE
feat: enhance hero messaging with animated background

### DIFF
--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -49,8 +49,8 @@ const Hero = () => {
   return (
     <section className="relative">
       <BackgroundPaths
-        title="Automatize Vendas Aumente Faturamento"
-        subtitle="Agentes de IA no WhatsApp, Instagram e Facebook + Landing Pages que convertem. Atendimento 24/7, agendamentos automáticos e mais tempo para focar no que realmente importa: crescer seu negócio."
+        title="Automatize seu atendimento e multiplique o faturamento"
+        subtitle="Agentes de IA no WhatsApp, Instagram e Facebook com landing pages que convertem. Mais comodidade para você e mais vendas para o seu negócio."
         primaryAction={primaryAction}
         secondaryAction={secondaryAction}
       />

--- a/src/components/ui/background-paths.tsx
+++ b/src/components/ui/background-paths.tsx
@@ -108,14 +108,14 @@ export function BackgroundPaths({
                     </h1>
 
                     {subtitle && (
-                        <motion.p 
+                        <motion.h2
                             initial={{ opacity: 0, y: 20 }}
                             animate={{ opacity: 1, y: 0 }}
                             transition={{ delay: 1, duration: 0.8 }}
                             className="text-lg sm:text-xl md:text-2xl text-muted-foreground mb-8 max-w-3xl mx-auto leading-relaxed"
                         >
                             {subtitle}
-                        </motion.p>
+                        </motion.h2>
                     )}
 
                     <motion.div 

--- a/src/components/ui/demo.tsx
+++ b/src/components/ui/demo.tsx
@@ -1,0 +1,6 @@
+import { BackgroundPaths } from "@/components/ui/background-paths";
+
+export function DemoBackgroundPaths() {
+    return <BackgroundPaths title="Background Paths" />;
+}
+


### PR DESCRIPTION
## Summary
- show 3D background subtitle as h2
- refine hero copy for better convenience and revenue messaging
- add demo for background paths component

## Testing
- `/usr/bin/env npm install framer-motion @radix-ui/react-slot class-variance-authority` *(fails: /usr/bin/env: ‘npm’: No such file or directory)*
- `/usr/bin/env npm run build` *(fails: /usr/bin/env: ‘npm’: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b51f8173ec833194e96643e6934aaf