### PR TITLE
chore: update deploy workflow actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,12 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clonar o repositório
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Configurar Node.js 18
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '18'
+          cache: 'npm'
 
       - name: Instalar dependências
         run: npm ci


### PR DESCRIPTION
## Summary
- bump actions/checkout and actions/setup-node to v4
- enable npm cache in setup-node

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: missing script)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b5237c1de4833184ceabb135d70bf2