### PR TITLE
Allow deployment from work branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - work
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
## Summary
- include `work` branch in deploy workflow triggers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-helmet)*
- `npm run lint` *(fails: eslint: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b52380dbf8833199c03957ce686f51