### PR TITLE
fix: correct ftp server directory

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,8 +37,8 @@ jobs:
           # pasta local com o build
           local-dir: dist/
 
-          # caminho do domínio principal no painel Hostinger
-          server-dir: /domains/agentiss.shop/public_html/
+          # caminho do domínio principal no painel Hostinger (relativo à raiz do FTP)
+          server-dir: domains/agentiss.shop/public_html/
 
           # NÃO limpar o servidor antes do upload
           dangerous-clean-slate: false


### PR DESCRIPTION
## Summary
- fix FTP server path to be relative to the root directory

## Testing
- `npm test` (fails: Missing script "test")
- `npm ci` (fails: 403 Forbidden - GET https://registry.npmjs.org/react-helmet)
- `npm run lint` (fails: Cannot find package '@eslint/js')


------
https://chatgpt.com/codex/tasks/task_e_68b52384d8408331af8cb4e43e5d1279