### PR TITLE
Refine marketing copy to highlight automation and CRM pain points

### DIFF
--- a/src/components/sections/CRMSection.tsx
+++ b/src/components/sections/CRMSection.tsx
@@ -76,12 +76,11 @@ export default function CRMSection() {
       <div className="container mx-auto px-6">
         <div className="text-center mb-16">
           <h2 className="text-4xl font-bold mb-4">
-            CRMs personalizados que{" "}
-            <span className="bg-gradient-primary bg-clip-text text-transparent">organizam</span>
+            Planilhas travam seu crescimento. Organize tudo em um CRM sob medida
           </h2>
           <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
-            Sistemas de gestão sob medida para seu negócio. Integração completa com 
-            agentes de IA, automações e relatórios inteligentes.
+            Pare de caçar dados em arquivos diferentes. Centralize leads, atendimentos e finanças com automações conectadas
+            aos agentes de IA, relatórios em tempo real e gatilhos que mantêm sua equipe focada no que gera receita.
           </p>
         </div>
 

--- a/src/components/sections/Features.tsx
+++ b/src/components/sections/Features.tsx
@@ -34,12 +34,12 @@ export default function Features() {
       <div className="container mx-auto px-6">
         <div className="text-center mb-16">
           <h2 className="text-4xl font-bold mb-4">
-            Atendimento automático que{" "}
-            <span className="bg-gradient-primary bg-clip-text text-transparent">resolve</span>
+            Atendimentos parados = vendas perdidas. Automatize agora
           </h2>
           <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
-            Respostas imediatas, qualificação de leads, <strong className="text-foreground">agendamento/confirmação</strong> e 
-            integrações com CRM/Calendário. Multicanal: WhatsApp, Instagram e Facebook.
+            Enquanto você responde manualmente, seus concorrentes já converteram. Respostas imediatas,{" "}
+            <strong className="text-foreground">agendamento/confirmação automáticos</strong>, qualificação de leads e integrações
+            com CRM/Calendário garantem que nenhum lead quente esfrie por falta de retorno.
           </p>
         </div>
 

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -27,20 +27,17 @@ export default function Hero() {
           <div className="space-y-4 sm:space-y-6 lg:space-y-8 animate-slide-up">
             <div className="space-y-3 sm:space-y-4 lg:space-y-6">
               <h1 className="text-3xl sm:text-4xl lg:text-5xl xl:text-6xl font-bold leading-tight">
-                Agentes de IA que{" "}
+                Pare de deixar dinheiro na mesa com atendimentos manuais
                 <span className="bg-gradient-primary bg-clip-text text-transparent">
-                  vendem 24/7
+                  . Venda 24/7
                 </span>
               </h1>
               <p className="text-base sm:text-lg lg:text-xl text-muted-foreground max-w-2xl leading-relaxed">
-                Tire dúvidas em tempo real,{" "}
-                <strong className="text-foreground">
-                  marque e confirme consultas
-                </strong>
-                ,<strong className="text-foreground"> qualifique leads</strong>{" "}
-                e integre com WhatsApp, Instagram e Facebook. Também criamos{" "}
-                <strong className="text-foreground">Landing Pages</strong> que
-                direcionam para as redes e aumentam a conversão.
+                Seus leads não podem esperar um horário comercial. Automatizamos o atendimento para{" "}
+                <strong className="text-foreground">marcar e confirmar consultas</strong>,{" "}
+                <strong className="text-foreground">qualificar interessados</strong>{" "}
+                e direcionar cada contato para o canal certo. Junto com uma{" "}
+                <strong className="text-foreground">Landing Page</strong> construída para conversão, você captura vendas que hoje escapam.
               </p>
             </div>
 

--- a/src/components/sections/LandingPages.tsx
+++ b/src/components/sections/LandingPages.tsx
@@ -49,12 +49,11 @@ export default function LandingPages() {
       <div className="container mx-auto px-6">
         <div className="text-center mb-16">
           <h2 className="text-4xl font-bold mb-4">
-            Landing Pages que{" "}
-            <span className="bg-gradient-primary bg-clip-text text-transparent">convertem</span>
+            Sem landing page, seu tráfego evapora. Vamos mudar isso
           </h2>
           <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
-            Páginas otimizadas para capturar leads e direcionar para WhatsApp, Instagram ou Facebook. 
-            Design responsivo e copy persuasiva.
+            Construímos páginas focadas em conversão para não perder quem já clicou no seu anúncio. Layouts rápidos, provas
+            sociais e chamadas claras que levam o lead direto para WhatsApp, Instagram ou automações de vendas.
           </p>
         </div>
 


### PR DESCRIPTION
## Summary
- Refocus the hero message on the cost of manter atendimentos manuais e apresentar a combinação de automação com landing pages
- Ajustar a seção de recursos para destacar perdas de vendas por respostas lentas e ressaltar automação de agenda e qualificação
- Atualizar a copy das seções de Landing Pages e CRM, enfatizando o desperdício de tráfego sem LP e a falta de organização em planilhas

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc10932b3c8331a4001afe5925c3cb